### PR TITLE
Update link to v5 docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ time you push up changes to your main branch, your deployed site will
 automatically update! This makes it very easy to add features even after you've
 deployed.
 
-[react-router]: https://reactrouter.com/web/guides/quick-start
+[react-router]: https://v5.reactrouter.com/web/guides/quick-start
 [APIs]: https://apilist.fun/
 [styled components]: https://styled-components.com/
 [react-bootstrap]: https://react-bootstrap.github.io/


### PR DESCRIPTION
The old link was directing to a 404 due to v5 no longer existing on the main reactrouter domain.